### PR TITLE
302 Temporary redirect, NOT 301 Permanent

### DIFF
--- a/aldryn_sites/middleware.py
+++ b/aldryn_sites/middleware.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals, absolute_import
 from django.conf import settings
-from django.http import HttpResponsePermanentRedirect
+from django.http import HttpResponseRedirect
 from . import utils
 
 
@@ -34,4 +34,4 @@ class SiteMiddleware(object):
         redirect_url = utils.get_redirect_url(current_url,
                                               config=site_config, https=self.secure_redirect)
         if redirect_url:
-            return HttpResponsePermanentRedirect(redirect_url)
+            return HttpResponseRedirect(redirect_url)


### PR DESCRIPTION
Permanent redirects are dangerous, because they are cached by browsers and it is easy to end up having a redirect loop for some users.