### PR TITLE
Add support for Django 1.8, 1.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=(
-        'Django>=1.5,<1.8',
+        'Django>=1.5,<1.10',
         'YURL>=0.13',
         'django-appconf',
     ),

--- a/test_requirements/base.txt
+++ b/test_requirements/base.txt
@@ -1,5 +1,3 @@
 pysqlite
 pytz
 coverage
-# the version that works with all supported Django versions
-django-cms==3.0.15

--- a/test_requirements/django_1.8.txt
+++ b/test_requirements/django_1.8.txt
@@ -1,0 +1,3 @@
+-r base.txt
+Django<1.9
+djangocms-helper>=0.9.2,<0.10

--- a/test_requirements/django_1.9.txt
+++ b/test_requirements/django_1.9.txt
@@ -1,0 +1,3 @@
+-r base.txt
+Django<1.10
+djangocms-helper>=0.9.2,<0.10

--- a/test_settings.py
+++ b/test_settings.py
@@ -30,7 +30,7 @@ HELPER_SETTINGS = {
 
 def run():
     from djangocms_helper import runner
-    runner.cms('aldryn_sites')
+    runner.run('aldryn_sites')
 
 
 if __name__ == "__main__":

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-dj{15,16,17},pep8
+envlist = py27-dj{15,16,17,18,19},pep8
 
 [testenv]
 commands =
@@ -7,19 +7,11 @@ commands =
     coverage run test_settings.py
     coverage report
 deps =
-    -rtest_requirements.txt
-
-[testenv:py27-dj15]
-deps =
-    -rtest_requirements/django_1.5.txt
-
-[testenv:py27-dj16]
-deps =
-    -rtest_requirements/django_1.6.txt
-
-[testenv:py27-dj17]
-deps =
-    -rtest_requirements/django_1.7.txt
+    dj15: -rtest_requirements/django_1.5.txt
+    dj16: -rtest_requirements/django_1.6.txt
+    dj17: -rtest_requirements/django_1.7.txt
+    dj18: -rtest_requirements/django_1.8.txt
+    dj19: -rtest_requirements/django_1.9.txt
 
 [testenv:pep8]
 commands = pep8 --repeat --show-source --max-line-length=120 --exclude=env,.tox,dist,migrations aldryn_sites setup.py


### PR DESCRIPTION
 - Remove Django CMS dependency in test environment. Use non-CMS runner.
 - Simplify tox setup.

(This simplification allows to support even Django 1.9 that is not
supported by Django CMS yet.)